### PR TITLE
Use substitute instead of matchstr

### DIFF
--- a/autoload/poetv.vim
+++ b/autoload/poetv.vim
@@ -63,7 +63,7 @@ function! poetv#activate() abort
                         break
                     endif
                 endfor
-                let poetv_out = matchstr(poetv_out, '\zs\S*')
+                let poetv_out = substitute(poetv_out, ' (Activated)$', '', '')
                 call setbufvar(curr_buffer_name, 'poetv_dir', poetv_out)
                 break
             else


### PR DESCRIPTION
Paths with spaces get truncated due to [this regex](https://github.com/PureFunctor/poet-v/blob/9f6a5828c80820c61d8031928044428e51a0ea73/autoload/poetv.vim#L66), which is fixed by instead using substitute to drop the ` (Activate)` suffix.